### PR TITLE
Added multi-author functionality. 

### DIFF
--- a/_includes/home_guide_promo.html
+++ b/_includes/home_guide_promo.html
@@ -23,7 +23,7 @@
                                 <p class="summary">{{ item.summary }}</p>
                                 <div class="guide-promo-profile">
                                     {% include profile.html profile=item.profile author=item.author  %}
-                                    <p class="bold">{{ item.author }}</p>
+                                    <p class="bold">{{ item.author }} {% if item.secondary_authors %}and others{% endif%}</p>
                                 </div>
                             </div>
                         </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -61,21 +61,44 @@ layout: default
                     </div>
                 </div>
                 <div id="right-column">
-                    <div id="guide-profile">
-                        <div>
-                            {% include profile.html profile=page.profile author=page.author  %}
+                    <div class="author-section">
+                        <div id="guide-profile">
+                            <div>
+                                {% include profile.html profile=page.profile author=page.author  %}
+                            </div>
+                            <div id="guide-profile-about">
+                                <p class="pt-0 mb-0 pb-0">by {{ page.author }}</p>
+                                <p class="mt-0 pt-0 mb-0 pb-0 bold underline-turquoise">{{ page.role }}</p>
+                            </div>
                         </div>
-                        <div id="guide-profile-about">
-                            <p class="pt-0 mb-0 pb-0">by {{ page.author }}</p>
-                            <p class="mt-0 pt-0 mb-0 pb-0 bold underline-turquoise">{{ page.role }}</p>
-                        </div>
+                        {% if page.bio %}
+                            <div id="bio">
+                                <br>
+                                {{ page.bio }}
+                            </div>
+                        {% endif %}
                     </div>
-                    {% if page.bio %}
-                        <div id="bio">
-                            {{ page.bio }}
+                    {% for secondary_author in page.secondary_authors %}
+                    <div class="author-section">
+                        <div style="display: flex; gap: 1rem;">
+                            <div>
+                                {% include profile.html profile=secondary_author.profile author=secondary_author.author %}
+                            </div>
+                            <div style="flex-direction: column;">
+                                <p class="pt-0 mb-0 pb-0">by {{ secondary_author.author }}</p>
+                                <p class="mt-0 pt-0 mb-0 pb-0 bold underline-turquoise">{{ secondary_author.role }}</p>
+                            </div>
                         </div>
-                    {% endif %}
+                        {% if secondary_author.bio %}
+                        <div style="width: 235px;">
+                            <br>
+                            {{ secondary_author.bio }}
+                        </div>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
                 </div>
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Added logic around "secondary_authors" list within practitioner guide front matter.
- To create a secondary author, first create a "secondary_authors" list, consisting of objects with the same fields as a normal author. This will look like this:
<img width="170" alt="image" src="https://github.com/ScottLogic/practitioners-guides/assets/142213102/73a3a3d0-f06d-4618-985c-f04a3522e424">

- Added "and others" to author name on homepage when there are secondary authors.

